### PR TITLE
Use a weaker check for valid environments to account for local dev.

### DIFF
--- a/test/tests.js
+++ b/test/tests.js
@@ -181,6 +181,20 @@ describe("Config tests", () => {
                 c.getRoute('missing');
             });
         });
+
+
+        it('loads all routes in local', () => {
+            let env = deepClone(mockEnvironmentRuntime);
+            delete env['PLATFORM_APPLICATION_NAME'];
+            delete env['PLATFORM_ENVIRONMENT'];
+            delete env['PLATFORM_BRANCH'];
+             let c = new psh.Config(env);
+
+            let routes = c.routes();
+
+            assert.ok(typeof routes == 'object');
+            assert.equal(Object.keys(routes).length, 4);
+        });
     });
 
     describe("Relationship tests", () => {


### PR DESCRIPTION
Just like in Python and PHP.

I had to refactor the way the property methods worked here, which ironically moves them closer to the logic in PHP.  Meh.