### PR TITLE
Revert "Add build status badge"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Platform.sh Config Reader (Node.js)
 
-[![CircleCI Status](https://circleci.com/gh/platformsh/config-reader-nodejs.svg?style=shield&circle-token=:circle-token)](https://circleci.com/gh/platformsh/config-reader-nodejs)
-
 This library provides a streamlined and easy to use way to interact with a Platform.sh environment.  It offers utility methods to access routes and relationships more cleanly than reading the raw environment variables yourself.
 
 This library requires Node.js 10 or later.


### PR DESCRIPTION
Reverts platformsh/config-reader-nodejs#3

The auto-publish script is incompatible with this, unfortunately.