### PR TITLE
Fix .circleci/config.yaml deploy workflow conditions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,11 +15,12 @@ workflows:
           requires:
             - build
           filters:
+          # Filters match ANY condition below. Specifying multiple filters does
+          # not specifically cause the workflow to run only when ALL are met.
             tags:
               only: /[0-9]+(\.[0-9]+)*/
             branches:
-              only:
-                - master
+              ignore: /.*/
 
 jobs:
   build:


### PR DESCRIPTION
Filters match run when ANY filter condition is matched; specifying multiple filters does not narrow down a workflow trigger to only be activated when ALL conditions are matched.