### PR TITLE
Allow custom prefix

### DIFF
--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -14,6 +14,8 @@ jobs:
               node-version: '10.x'
               registry-url: 'https://registry.npmjs.org'
         - run: npm install
-        - run: npm publish
+        - if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
           env:
               NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          run: npm publish
+

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -1,0 +1,19 @@
+---
+name: Publish (npm)
+on:
+    push: ~
+
+jobs:
+    deploy:
+        name: Publish to npm
+        runs-on: ubuntu-latest
+        steps:
+        - uses: actions/checkout@v2
+        - uses: actions/setup-node@v2
+          with:
+              node-version: '10.x'
+              registry-url: 'https://registry.npmjs.org'
+        - run: npm install
+        - run: npm publish
+          env:
+              NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/quality-assurance.yaml
+++ b/.github/workflows/quality-assurance.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
     build:
-        name: [Build/test] Node.js ${{ matrix.nodejs }}
+        name: '[Build/test] Node.js ${{ matrix.nodejs }}'
         runs-on: ubuntu-latest
         strategy:
             matrix:

--- a/.github/workflows/quality-assurance.yaml
+++ b/.github/workflows/quality-assurance.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
     build:
-        name: Build and test on ${{ matrix.nodejs }}
+        name: [Build/test] Node.js ${{ matrix.nodejs }}
         runs-on: ubuntu-latest
         strategy:
             matrix:

--- a/.github/workflows/quality-assurance.yaml
+++ b/.github/workflows/quality-assurance.yaml
@@ -10,7 +10,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                nodejs: [ '10.x', '12.x', '14.x' ]
+                nodejs: [ '10', '12', '14' ]
         steps: 
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v1

--- a/.github/workflows/quality-assurance.yaml
+++ b/.github/workflows/quality-assurance.yaml
@@ -10,7 +10,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                node.js: [ '10', '12', '14' ]
+                nodejs: [ '10.x', '12.x', '14.x' ]
         steps: 
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v1

--- a/.github/workflows/quality-assurance.yaml
+++ b/.github/workflows/quality-assurance.yaml
@@ -1,0 +1,21 @@
+---
+name: Quality Assurance
+on:
+    push: ~
+    pull_request: ~
+
+jobs:
+    build:
+        name: Build and test on ${{ matrix.nodejs }}
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                node.js: [ '10.x', '12.x', '14.x' ]
+        steps: 
+            - uses: actions/checkout@v2
+            - uses: actions/setup-node@v1
+              with:
+                  node-version: ${{ matrix.nodejs }}
+            - run: npm install
+            - run: npm run build --if-present
+            - run: npm test

--- a/.github/workflows/quality-assurance.yaml
+++ b/.github/workflows/quality-assurance.yaml
@@ -10,7 +10,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                node.js: [ '10.x', '12.x', '14.x' ]
+                node.js: [ '10', '12', '14' ]
         steps: 
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v1

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ node_modules
 lib
 
 package-lock.json
+.github/workflows/npm-publish.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,3 @@ node_modules
 lib
 
 package-lock.json
-.github/workflows/npm-publish.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,18 @@
 # Changelog
 
-## [2.4.0] - 2020-11-17
+## [2.4.0] - 2021-02-03
 
 ### Added
 
+* GitHub actions for tests (`quality-assurance.yaml`) and publishing to npm (`npm-publish.yaml`).
+
+### Changed 
+
 * `config` method can now get an object `{ varPrefix: string }` to specify a different environment variables prefix.
+
+### Removed
+
+* CircleCI action config. 
 
 ## [2.3.1] - 2019-11-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.4.0] - 2020-11-17
+
+### Added
+
+* `config` method can now get an object `{ varPrefix: string }` to specify a different environment variables prefix.
+
 ## [2.3.1] - 2019-11-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Platform.sh Config Reader (Node.js)
 
+![Quality Assurance](https://github.com/platformsh/config-reader-nodejs/workflows/Quality%20Assurance/badge.svg)
+
 This library provides a streamlined and easy to use way to interact with a Platform.sh environment.  It offers utility methods to access routes and relationships more cleanly than reading the raw environment variables yourself.
 
 This library requires Node.js 10 or later.

--- a/README.md
+++ b/README.md
@@ -106,6 +106,13 @@ config.socket;
 config.port;
 ```
 
+By default, Platform.sh environment variables are prefixed with `PLATFORM_`. In some cases, you might need to change this default in order to have access to environment variables at build time (like with [create-react-app](https://create-react-app.dev/docs/adding-custom-environment-variables/)).
+
+You can do this like so:
+```js
+const config = require("platformsh-config").config({ varPrefix: "MY_PREFIX_" });
+```
+
 ### Reading service credentials
 
 [Platform.sh services](https://docs.platform.sh/configuration/services.html) are defined in a `services.yaml` file, and exposed to an application by listing a `relationship` to that service in the application's `.platform.app.yaml` file.  User, password, host, etc. information is then exposed to the running application in the `PLATFORM_RELATIONSHIPS` environment variable, which is a base64-encoded JSON string.  The following method allows easier access to credential information than decoding the environment variable yourself.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "platformsh-config",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "Helper for running nodejs applications on Platform.sh",
   "main": "lib/platformsh.js",
   "keywords": [

--- a/src/platformsh.js
+++ b/src/platformsh.js
@@ -24,9 +24,9 @@ function decode(value) {
  */
 class Config {
 
-    constructor(env = null, prefix = 'PLATFORM_') {
+    constructor(env = null, varPrefix = 'PLATFORM_') {
         this.environmentVariables = env || process.env;
-        this.envPrefix = prefix;
+        this.varPrefix = varPrefix;
 
         // Node doesn't support pre-defined object properties in classes, so
         // this is mostly for documentation but also to ensure there's always
@@ -567,7 +567,7 @@ class Config {
      * @return {string|null}
      */
     _getValue(name) {
-        let checkName = this.envPrefix + name.toUpperCase();
+        let checkName = this.varPrefix + name.toUpperCase();
 
         return this.environmentVariables[checkName] || null;
     }
@@ -619,9 +619,9 @@ function puppeteerFormatter(credentials) {
  *
  * @returns {Config}
  */
-function config() {
+function config({ varPrefix } = {}) {
 
-    return new Config();
+    return new Config(null, varPrefix);
 }
 
 module.exports = {

--- a/test/testdata/ENV.json
+++ b/test/testdata/ENV.json
@@ -5,5 +5,7 @@
     "PLATFORM_TREE_ID": "abc123",
     "PLATFORM_PROJECT_ENTROPY": "def789",
 
-    "SOME_VARIABLE": "some value"
+    "SOME_VARIABLE": "some value",
+
+    "CUSTOM_PREFIX_VARIABLE_WITH_CUSTOM_PREFIX": "with custom prefix"
 }

--- a/test/tests.js
+++ b/test/tests.js
@@ -22,7 +22,7 @@ describe("Config tests", () => {
     let mockEnvironmentRuntime = [];
 
     before(() => {
-        let env = loadJsonFile('ENV');
+        const env = loadJsonFile('ENV');
 
         ['PLATFORM_APPLICATION', 'PLATFORM_VARIABLES'].forEach((item) => {
             env[item] = encode(loadJsonFile(item));
@@ -34,28 +34,27 @@ describe("Config tests", () => {
             env[item] = encode(loadJsonFile(item));
         });
 
-        let envRuntime = loadJsonFile('ENV_runtime');
-        env = {...env, ...envRuntime};
+        const envRuntime = loadJsonFile('ENV_runtime');
 
-        mockEnvironmentRuntime = env;
+        mockEnvironmentRuntime = {...env, ...envRuntime};
     });
 
     describe("isValidPlatform() tests", () => {
 
         it('Returns false when not on Platform.sh', () => {
-            let c = new psh.Config();
+            const c = new psh.Config();
 
             assert.ok(!c.isValidPlatform());
         });
 
         it('Returns true when on Platform.sh, build time', () => {
-            let c = new psh.Config(mockEnvironmentBuild);
+            const c = new psh.Config(mockEnvironmentBuild);
 
             assert.ok(c.isValidPlatform());
         });
 
         it('Returns true when on Platform.sh, runtime', () => {
-            let c = new psh.Config(mockEnvironmentRuntime);
+            const c = new psh.Config(mockEnvironmentRuntime);
 
             assert.ok(c.isValidPlatform());
         });
@@ -64,13 +63,13 @@ describe("Config tests", () => {
     describe("inBuid() tests", () => {
 
         it('Returns true in build environment', () => {
-            let c = new psh.Config(mockEnvironmentBuild);
+            const c = new psh.Config(mockEnvironmentBuild);
 
             assert.ok(c.inBuild())
         });
 
         it('Returns false in runtime environment', () => {
-            let c = new psh.Config(mockEnvironmentRuntime);
+            const c = new psh.Config(mockEnvironmentRuntime);
 
             assert.ok(!c.inBuild())
         });
@@ -80,13 +79,13 @@ describe("Config tests", () => {
     describe("inRuntime() tests", () => {
 
         it('Returns true in runtime environment', () => {
-            let c = new psh.Config(mockEnvironmentRuntime);
+            const c = new psh.Config(mockEnvironmentRuntime);
 
             assert.ok(c.inRuntime());
         });
 
         it('Returns false in build environment', () => {
-            let c = new psh.Config(mockEnvironmentBuild);
+            const c = new psh.Config(mockEnvironmentBuild);
 
             assert.ok(!c.inRuntime());
         });
@@ -95,16 +94,16 @@ describe("Config tests", () => {
     describe("onDedicated() tests", () => {
 
         it('Returns true in Dedicated environment', () => {
-            let mockEnvironmentDedicated = deepClone(mockEnvironmentRuntime);
+            const mockEnvironmentDedicated = deepClone(mockEnvironmentRuntime);
             mockEnvironmentDedicated['PLATFORM_MODE'] = 'enterprise';
 
-            let c = new psh.Config(mockEnvironmentDedicated);
+            const c = new psh.Config(mockEnvironmentDedicated);
 
             assert.ok(c.onDedicated());
         });
 
         it('Returns false in standard environment', () => {
-            let c = new psh.Config(mockEnvironmentRuntime);
+            const c = new psh.Config(mockEnvironmentRuntime);
 
             assert.ok(!c.onDedicated());
         });
@@ -113,35 +112,35 @@ describe("Config tests", () => {
     describe("onProduction() tests", () => {
 
         it('Returns true on Dedicated production', () => {
-            let mockEnvironmentDedicated = deepClone(mockEnvironmentRuntime);
+            const mockEnvironmentDedicated = deepClone(mockEnvironmentRuntime);
             mockEnvironmentDedicated['PLATFORM_MODE'] = 'enterprise';
             mockEnvironmentDedicated['PLATFORM_BRANCH'] = 'production';
 
-            let c = new psh.Config(mockEnvironmentDedicated);
+            const c = new psh.Config(mockEnvironmentDedicated);
 
             assert.ok(c.onProduction());
         });
 
         it('Returns false on Dedicated staging', () => {
-            let mockEnvironmentDedicated = deepClone(mockEnvironmentRuntime);
+            const mockEnvironmentDedicated = deepClone(mockEnvironmentRuntime);
             mockEnvironmentDedicated['PLATFORM_MODE'] = 'enterprise';
 
-            let c = new psh.Config(mockEnvironmentDedicated);
+            const c = new psh.Config(mockEnvironmentDedicated);
 
             assert.ok(!c.onProduction());
         });
 
         it('Returns true on standard master', () => {
-            let mockEnvironmentProduction = deepClone(mockEnvironmentRuntime);
+            const mockEnvironmentProduction = deepClone(mockEnvironmentRuntime);
             mockEnvironmentProduction['PLATFORM_BRANCH'] = 'master';
 
-            let c = new psh.Config(mockEnvironmentProduction);
+            const c = new psh.Config(mockEnvironmentProduction);
 
             assert.ok(c.onProduction());
         });
 
         it('Returns false on standard dev', () => {
-            let c = new psh.Config(mockEnvironmentRuntime);
+            const c = new psh.Config(mockEnvironmentRuntime);
 
             assert.ok(!c.onProduction());
         });
@@ -150,74 +149,74 @@ describe("Config tests", () => {
     describe("Route tests", () => {
 
         it('loads all routes in runtime', () => {
-            let c = new psh.Config(mockEnvironmentRuntime);
+            const c = new psh.Config(mockEnvironmentRuntime);
 
-            let routes = c.routes();
+            const routes = c.routes();
 
             assert.ok(typeof routes == 'object');
             assert.equal(Object.keys(routes).length, 6);
         });
 
         it('throws when loading routes in build time', () => {
-            let c = new psh.Config(mockEnvironmentBuild);
+            const c = new psh.Config(mockEnvironmentBuild);
 
             assert.throws(() => {
-                let routes = c.routes();
+                const routes = c.routes();
             });
         });
 
         it('gets the primary route', () => {
-            let c = new psh.Config(mockEnvironmentRuntime);
+            const c = new psh.Config(mockEnvironmentRuntime);
 
-            let route = c.getPrimaryRoute();
+            const route = c.getPrimaryRoute();
 
             assert.equal(route['original_url'], 'https://www.{default}/');
             assert.equal(route['primary'], true);
         });
 
         it('returns all upstream routes', () => {
-            let c = new psh.Config(mockEnvironmentRuntime);
+            const c = new psh.Config(mockEnvironmentRuntime);
 
-            let routes = c.getUpstreamRoutes();
+            const routes = c.getUpstreamRoutes();
 
             assert.equal(3, Object.keys(routes).length);
             assert.equal(routes['https://www.master-7rqtwti-gcpjkefjk4wc2.us-2.platformsh.site/']['original_url'], 'https://www.{default}/');
         });
 
         it('returns all upstream routes for a specific app', () => {
-            let c = new psh.Config(mockEnvironmentRuntime);
+            const c = new psh.Config(mockEnvironmentRuntime);
 
-            let routes = c.getUpstreamRoutes('app');
+            const routes = c.getUpstreamRoutes('app');
 
             assert.equal(2, Object.keys(routes).length);
             assert.equal(routes['https://www.master-7rqtwti-gcpjkefjk4wc2.us-2.platformsh.site/']['original_url'], 'https://www.{default}/');
         });
 
         it('returns all upstream routes for a specific app on dedicated', () => {
-            let env = mockEnvironmentRuntime;
+            const env = mockEnvironmentRuntime;
             // Simulate a Dedicated-style upstream name.
-            let routeData = loadJsonFile('PLATFORM_ROUTES');
+            const routeData = loadJsonFile('PLATFORM_ROUTES');
             routeData['https://www.master-7rqtwti-gcpjkefjk4wc2.us-2.platformsh.site/']['upstream'] = 'app:http';
             env['PLATFORM_ROUTES'] = encode(routeData);
 
-            let c = new psh.Config(env);
+            const c = new psh.Config(env);
 
-            let routes = c.getUpstreamRoutes('app');
+            const routes = c.getUpstreamRoutes('app');
 
             assert.equal(2, Object.keys(routes).length);
             assert.equal(routes['https://www.master-7rqtwti-gcpjkefjk4wc2.us-2.platformsh.site/']['original_url'], 'https://www.{default}/');
         });
 
         it('gets a route by id', () => {
-            let c = new psh.Config(mockEnvironmentRuntime);
+            const c = new psh.Config(mockEnvironmentRuntime);
 
-            let route = c.getRoute('main');
+            const route = c.getRoute('main');
 
             assert.equal(route['original_url'], 'https://www.{default}/');
         });
 
         it('throws on a non-existant route id', () => {
-            let c = new psh.Config(mockEnvironmentRuntime);
+            const c = new psh.Config(mockEnvironmentRuntime);
 
             assert.throws(() => {
                 c.getRoute('missing');
@@ -226,13 +225,13 @@ describe("Config tests", () => {
 
 
         it('loads all routes in local', () => {
-            let env = deepClone(mockEnvironmentRuntime);
+            const env = deepClone(mockEnvironmentRuntime);
             delete env['PLATFORM_APPLICATION_NAME'];
             delete env['PLATFORM_ENVIRONMENT'];
             delete env['PLATFORM_BRANCH'];
-             let c = new psh.Config(env);
+             const c = new psh.Config(env);
 
-            let routes = c.routes();
+            const routes = c.routes();
 
             assert.ok(typeof routes == 'object');
             assert.equal(Object.keys(routes).length, 6);
@@ -242,27 +241,27 @@ describe("Config tests", () => {
     describe("Relationship tests", () => {
 
         it('returns an existing relationship by name', () => {
-            let c = new psh.Config(mockEnvironmentRuntime);
+            const c = new psh.Config(mockEnvironmentRuntime);
 
-            let creds = c.credentials('database');
+            const creds = c.credentials('database');
 
             assert.equal(creds['scheme'], 'mysql');
             assert.equal(creds['type'], 'mysql:10.2');
         });
 
         it('throws an exception for a missing relationship name', () => {
-            let c = new psh.Config(mockEnvironmentRuntime);
+            const c = new psh.Config(mockEnvironmentRuntime);
 
             assert.throws(() => {
-                let creds = c.getRoute('missing');
+                const creds = c.getRoute('missing');
             });
         });
 
         it('throws an exception for a missing relationship index', () => {
-            let c = new psh.Config(mockEnvironmentRuntime);
+            const c = new psh.Config(mockEnvironmentRuntime);
 
             assert.throws(() => {
-                let creds = c.getRoute('database', 3);
+                const creds = c.getRoute('database', 3);
             });
         });
     });
@@ -270,13 +269,13 @@ describe("Config tests", () => {
     describe('hasRelationship tests', () => {
 
         if('returns true for an existing relationship', () => {
-            let c = new psh.Config(mockEnvironmentRuntime);
+            const c = new psh.Config(mockEnvironmentRuntime);
 
             assert.ok(c.hasRelationship('database'));
         });
 
         if('returns false for an missing relationship', () => {
-            let c = new psh.Config(mockEnvironmentRuntime);
+            const c = new psh.Config(mockEnvironmentRuntime);
 
             assert.ok(c.hasRelationship('missing'));
         });
@@ -285,25 +284,25 @@ describe("Config tests", () => {
     describe("Variables tests", () => {
 
         it('returns an existing variable', () => {
-            let c = new psh.Config(mockEnvironmentRuntime);
+            const c = new psh.Config(mockEnvironmentRuntime);
 
-            let value = c.variable('somevar');
+            const value = c.variable('somevar');
 
             assert.equal(value, 'someval');
         });
 
         it('returns a default value when the variable doesn\'t exist', () => {
-            let c = new psh.Config(mockEnvironmentRuntime);
+            const c = new psh.Config(mockEnvironmentRuntime);
 
-            let value = c.variable('missing', 'default-val');
+            const value = c.variable('missing', 'default-val');
 
             assert.equal(value, 'default-val');
         });
 
         it('returns all variables when on Platform', () => {
-            let c = new psh.Config(mockEnvironmentRuntime);
+            const c = new psh.Config(mockEnvironmentRuntime);
 
-            let value = c.variables();
+            const value = c.variables();
 
             assert.equal(value['somevar'], 'someval');
         });
@@ -312,9 +311,9 @@ describe("Config tests", () => {
     describe("Application tests", () => {
 
         it('returns the application array on Platform.sh', () => {
-            let c = new psh.Config(mockEnvironmentRuntime);
+            const c = new psh.Config(mockEnvironmentRuntime);
 
-            let app = c.application();
+            const app = c.application();
 
             assert.equal(app['type'], 'php:7.2');
         });
@@ -324,7 +323,7 @@ describe("Config tests", () => {
     describe("Raw property tests", () => {
 
         it('returns the correct value for raw properties', () => {
-            let c = new psh.Config(mockEnvironmentRuntime);
+            const c = new psh.Config(mockEnvironmentRuntime);
 
             assert.equal(c.appDir, '/app');
             assert.equal(c.applicationName, 'app');
@@ -341,10 +340,10 @@ describe("Config tests", () => {
         });
 
         it('throws when a runtime property is accessed at build time', () => {
-            let c = new psh.Config(mockEnvironmentBuild);
+            const c = new psh.Config(mockEnvironmentBuild);
 
             assert.throws(() => {
-                let branch = c.branch;
+                const branch = c.branch;
             });
         });
     });
@@ -352,7 +351,7 @@ describe("Config tests", () => {
     describe('Credential formatter tests', () => {
 
         it('throws when a formatter is not found', () => {
-            let c = new psh.Config(mockEnvironmentRuntime);
+            const c = new psh.Config(mockEnvironmentRuntime);
 
             assert.throws(() => {
                 c.formattedCredentials('database', 'not-existing');
@@ -360,7 +359,7 @@ describe("Config tests", () => {
         });
 
         it('calls a registered formatter', () => {
-            let c = new psh.Config(mockEnvironmentRuntime);
+            const c = new psh.Config(mockEnvironmentRuntime);
             let called = false;
 
             c.registerFormatter('test', (credentials) => {
@@ -368,16 +367,16 @@ describe("Config tests", () => {
                 return 'stuff';
             });
 
-            let formatted = c.formattedCredentials('database', 'test');
+            const formatted = c.formattedCredentials('database', 'test');
 
             assert.ok(called);
             assert.equal(formatted, 'stuff');
         });
 
         it('formats a solr-node connection', () => {
-            let c = new psh.Config(mockEnvironmentRuntime);
+            const c = new psh.Config(mockEnvironmentRuntime);
 
-            let formatted = c.formattedCredentials('solr', 'solr-node');
+            const formatted = c.formattedCredentials('solr', 'solr-node');
 
             assert.deepEqual(formatted, {
                 host: 'solr.internal',
@@ -388,9 +387,9 @@ describe("Config tests", () => {
         });
 
         it('formatts a puppeteer connection', () => {
-            let c = new psh.Config(mockEnvironmentRuntime);
+            const c = new psh.Config(mockEnvironmentRuntime);
 
-            let formatted = c.formattedCredentials('headless', 'puppeteer')
+            const formatted = c.formattedCredentials('headless', 'puppeteer')
 
             assert.equal(formatted, 'http://169.254.16.215:9222')
         });

--- a/test/tests.js
+++ b/test/tests.js
@@ -306,6 +306,16 @@ describe("Config tests", () => {
 
             assert.equal(value['somevar'], 'someval');
         });
+
+        it('return a variable with a custom prefix', () => {
+            const c = new psh.Config(mockEnvironmentRuntime, "CUSTOM_PREFIX_");
+
+            const withCustomPrefix = c._getValue("variable_with_custom_prefix");
+            const hasNoCustomPrefix = c._getValue("somevar");
+
+            assert.equal(withCustomPrefix, "with custom prefix");
+            assert.equal(hasNoCustomPrefix, null);
+        });
     });
 
     describe("Application tests", () => {


### PR DESCRIPTION
Some tools such as [create-react-app](https://github.com/facebook/create-react-app) only expose specifically prefixed environment variables (for CRA, it's `REACT_APP_`) and do so only at build time. Since Create React App produces a static HTML/CSS/JS bundle, it can’t possibly read them at runtime.

This is problematic when we need access to `PLATFORM_*` environment variables.
To do so, we need to be able to specify a custom prefix so we can pick up the re-exported relevant variables with the prefix.

Then we can do:
#### .platform.app.yaml
```yaml
hooks:
  deploy: |
    set -e
    REACT_APP_PLATFORM_ROUTES=$PLATFORM_ROUTES \
    REACT_APP_PLATFORM_RELATIONSHIPS=$PLATFORM_RELATIONSHIPS \
    yarn build
```

#### somewhere.js
```javascript
import { config as platformConfig } from "platformsh-config";

// use React-specific prefix
const config = platformConfig({ varPrefix: "REACT_APP_PLATFORM_" });
const {
  environmentVariables: { NODE_ENV },
  isDev = NODE_ENV === "development",
} = config;

const getApiUrl = () => {
  // using platform?
  if (config.hasRelationship("api")) {
    const { host, port } = config.credentials("api");

    // local dev with ssh tunnel
    if (isDev) {
      return `http://${host}:${port}`;
    }

    // prod, we need the api route url
    const url = Object.entries(config.routes()).find(
      ([, { upstream }]) => upstream === "api"
    )[0];

    return `${url}:${port}`;
  }

  // local dev with local server
  return `http://localhost:4000`;
};
```